### PR TITLE
Adding Codeowners and Dependabot functionality

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default owners for all files
+* @SiebenCorgie
+
+# Override the default owners and remove ownership for Cargo.toml files to allow auto dependabot updates
+Cargo.toml
+examples/esp32s3/Cargo.toml
+
+# Override the default owners and remove ownership for the .github/workflows directory
+.github/workflows/

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,25 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directories:
+      - "/" # Library Crate
+      - "/examples/*"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/pull_request-template.md
+++ b/.github/pull_request-template.md
@@ -1,0 +1,25 @@
+# Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+## Type of change
+
+Please score/delete out the options that are not relevant.
+
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- This change requires a documentation update
+
+## How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. This is particularly relevant when discussing bugs.
+
+## Checklist
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I Have locally ran [MegaLinter](https://megalinter.io/latest/supported-linters/) see [README](../README.md) for more details Command: `npx mega-linter-runner --fix`

--- a/.github/pull_request-template.md
+++ b/.github/pull_request-template.md
@@ -22,4 +22,4 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
-- [ ] I Have locally ran [MegaLinter](https://megalinter.io/latest/supported-linters/) see [README](../README.md) for more details Command: `npx mega-linter-runner --fix`
+- [ ] I Have locally ran [MegaLinter](https://megalinter.io/latest/supported-linters/) see [README](../README.md) for more details. You can use the following Bash/zsh command: `npx mega-linter-runner --fix`

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,15 +1,15 @@
 ---
-    name: Dependabot Auto Merge
-    on:
-      pull_request:
-        branches:
-          - main
-    jobs:
-      auto-merge:
-        runs-on: ubuntu-latest
-        steps:
-          - uses: actions/checkout@v4
-          - uses: ahmadnassri/action-dependabot-auto-merge@v2
-            with:
-              target: minor
-              github-token: ${{ secrets.dependabot }}
+name: Dependabot Auto Merge
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.dependabot }}

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,15 @@
+---
+    name: Dependabot Auto Merge
+    on:
+      pull_request:
+        branches:
+          - main
+    jobs:
+      auto-merge:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v4
+          - uses: ahmadnassri/action-dependabot-auto-merge@v2
+            with:
+              target: minor
+              github-token: ${{ secrets.dependabot }}

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ cargo run --example os_sync_basic --no-default-features --features sync
 ```
 
 More information on this can be found [here](https://github.com/dysonltd/tmag5273/blob/main/examples/README.md).
+
 ## Running your Linter Locally
+
 This project uses [MegaLinter](https://github.com/oxsecurity/megalinter) which provides linters for various different file formats and languages. When a Pull request to main is done, the linters will run and ensure the codebase is in good standing. It is recommended that you run the linter locally beforehand as it can sometimes autofix common mistakes.
 
 ```bash
@@ -57,7 +59,9 @@ npx mega-linter-runner
 ```
 
 You will need to have docker and Node installed to use this, more information can be found on their [repo](https://github.com/oxsecurity/megalinter)
+
 ### Issues with rust fmt
+
 Currently at the time of this commit `rust fmt` is not supported as part of MegaLinter, thus to ensure it is correctly formatted we have added an extra build stage which can be seen [here](./.github/workflows/mega-linter.yaml). You can run this locally using
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You will need to have docker and Node installed to use this, more information ca
 
 ### Issues with Running Mega Linter on Forks
 
-Sadly due to the way GitHub handles PAT Tokens we are unable to run all of MegaLinters functionality when processing Pull Requests from forks. It is recommended that you run the linter locally as stated above, otherwise you can setup your own PAT token for your fork repository and make a PR there in which you will receive the full capability of MegaLinter.
+Sadly due to the way GitHub handles PAT Tokens we are unable to run all of MegaLinters functionality when processing Pull Requests from forks. It is recommended that you run the linter locally as stated above, otherwise you can [setup your own PAT token](https://github.com/marketplace/actions/megalinter#apply-fixes-issues) for your fork repository and make a PR there in which you will receive the full capability of MegaLinter.
 
 #### PAT Token for Mega Linter running on Forks
 
@@ -70,7 +70,6 @@ There are Two PAT Tokens requred for full GitHub MegaLinter functionality. One i
 
 - Commit Statuses: Read and Write
 - Contents: Read and Write
-- Issues: Read and Write
 - Pull Requests: Read and Write
 - Work Flows: Read and Write
 
@@ -92,7 +91,6 @@ As such it requires another PAT Token named `DEPENDABOT` with the following cred
 
 - Commit Statuses: Read and Write
 - Contents: Read and Write
-- Issues: Read and Write
 - Pull Requests: Read and Write
 - Work Flows: Read and Write
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,40 @@ You will need to have docker and Node installed to use this, more information ca
 
 Sadly due to the way GitHub handles PAT Tokens we are unable to run all of MegaLinters functionality when processing Pull Requests from forks. It is recommended that you run the linter locally as stated above, otherwise you can setup your own PAT token for your fork repository and make a PR there in which you will receive the full capability of MegaLinter.
 
+#### PAT Token for Mega Linter running on Forks
+
+There are Two PAT Tokens requred for full GitHub MegaLinter functionality. One is already for you which is the `secrets.GITHUB_TOKEN` however to get the full functionality you will be required to create a new PAT Token with the following settings:
+
+- Commit Statuses: Read and Write
+- Contents: Read and Write
+- Issues: Read and Write
+- Pull Requests: Read and Write
+- Work Flows: Read and Write
+
+If this is your first time creating a Mega Linter PAT Token it may be recommended to create it for all Repositories so you can use it for multiple projects.
+
+This will enable MegaLinter to create PRs and modify files.
+
+More on this can be found here:
+
+<https://megalinter.io/latest/install-github/>
+
+<https://github.com/oxsecurity/megalinter/issues/4317>
+
+#### PAT Token for Dependabot (Main Repo Only)
+
+This repository also contains a workflow for auto merging Dependabot updates. ([Workflow](./.github/workflows/dependabot.yaml)) ([Dependabot Configuration](./.github/dependabot.yaml)).
+
+As such it requires another PAT Token named `DEPENDABOT` with the following credentials
+
+- Commit Statuses: Read and Write
+- Contents: Read and Write
+- Issues: Read and Write
+- Pull Requests: Read and Write
+- Work Flows: Read and Write
+
+More on this GitHub action can be found [here](https://github.com/marketplace/actions/dependabot-auto-merge).
+
 ### Issues with rust fmt
 
 Currently at the time of this commit `rust fmt` is not supported as part of MegaLinter, thus to ensure it is correctly formatted we have added an extra build stage which can be seen [here](./.github/workflows/mega-linter.yaml). You can run this locally using

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ npx mega-linter-runner
 
 You will need to have docker and Node installed to use this, more information can be found on their [repo](https://github.com/oxsecurity/megalinter)
 
+### Issues with Running Mega Linter on Forks
+
+Sadly due to the way GitHub handles PAT Tokens we are unable to run all of MegaLinters functionality when processing Pull Requests from forks. It is recommended that you run the linter locally as stated above, otherwise you can setup your own PAT token for your fork repository and make a PR there in which you will receive the full capability of MegaLinter.
+
 ### Issues with rust fmt
 
 Currently at the time of this commit `rust fmt` is not supported as part of MegaLinter, thus to ensure it is correctly formatted we have added an extra build stage which can be seen [here](./.github/workflows/mega-linter.yaml). You can run this locally using


### PR DESCRIPTION
# Whats Changed

- Added Dependabot, this will check for dependency updates weekly for the rust cargo.toml files, it will also check Github action files as well. This will create a PR into main with the dependencies updated.
- Added Dependabot auto merge, this workflow will automatically merge in the dependency updates if all of our CI passes. At the moment we are just ensuring that the example compiles and the library compiles with the different features.


# What needs to be done pre merge

- [ ] Dependabot Token - This one is a little bit special as it needs to be able to modify action files too in order to update them, if this setting isnt set correctly then dependabot will fail to update these deps too.
~~- [ ] MegaLinter Token Fix - See below comment~~