### PR TITLE
Add test harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Implemented **Breaking** changes to the API and introduced further type safety to the internal code structure.
 - Added Debug macro to internal/external data structures
+- Added first iteration of test harness for the library
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,8 +161,6 @@ dependencies = [
  "maybe-async",
  "num_enum",
  "shared-bus",
- "strum",
- "strum_macros",
  "tests-common",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "mpr121-hal"
-version = "0.6.0"
+version = "0.5.0"
 dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -261,8 +261,8 @@ name = "tests-common"
 version = "0.1.0"
 dependencies = [
  "embedded-hal 1.0.0",
+ "embedded-hal-async",
  "embedded-hal-bus",
- "maybe-async",
  "mpr121-hal",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +36,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
 dependencies = [
+ "embedded-hal 1.0.0",
+]
+
+[[package]]
+name = "embedded-hal-bus"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513e0b3a8fb7d3013a8ae17a834283f170deaf7d0eeab0a7c1a36ad4dd356d22"
+dependencies = [
+ "critical-section",
  "embedded-hal 1.0.0",
 ]
 
@@ -153,6 +169,7 @@ dependencies = [
  "shared-bus",
  "strum",
  "strum_macros",
+ "tests-common",
 ]
 
 [[package]]
@@ -270,6 +287,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tests-common"
+version = "0.1.0"
+dependencies = [
+ "embedded-hal 1.0.0",
+ "embedded-hal-bus",
+ "maybe-async",
+ "mpr121-hal",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpr121-hal"
-version = "1.0.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Tendsin Mende <tendsin@protonmail.com>", "Scott Gibb <smgibb@yahoo.com"]
 repository = "https://gitlab.com/tendsinmende/mpr121-hal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ ftdi-embedded-hal = { version = "0.23.0", features = [
     "libftd2xx-static",
 ] }
 shared-bus = "0.3.1"
-tests-common ={ path = "./tests-common" }
+tests-common ={ path = "./tests-common", features = ["sync"]}
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,4 +52,9 @@ ftdi-embedded-hal = { version = "0.23.0", features = [
     "libftd2xx-static",
 ] }
 shared-bus = "0.3.1"
+tests-common ={ path = "./tests-common" }
 
+[workspace]
+members = [
+    "tests-common"
+]

--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ Currently at the time of this commit `rust fmt` is not supported as part of Mega
 cargo fmt --all
 ```
 
+## Running Integration Tests
+
+At present there is limited integration tests for the driver. Generic tests that can be applied across numerous architectures/platforms are stored in a [sub crate](./tests-common/) within the repository. These are platform agnostic and are focused on the driver itself. Within the [tests](./tests/) directory are platform dependent tests which can run on the developer OS or MCU platforms.
+
+When running the tests on the developer platform with the FT232H Breakout Board, you will need to run them single threaded and not in parallel. This is due to there only being one I2C hardware block and the locking around that. To do that, run the following command:
+
+```bash
+cargo test -- --test-threads=1
+```
+
 ## License
 
 Licensed under either of

--- a/examples/esp32s3/Cargo.lock
+++ b/examples/esp32s3/Cargo.lock
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "mpr121-hal"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "embedded-hal-async",
  "maybe-async",

--- a/src/mpr121.rs
+++ b/src/mpr121.rs
@@ -173,7 +173,7 @@ impl<I2C: I2c> Mpr121<I2C> {
         for i in 0..Channel::get_num_channels() {
             //Note ignoring false set thresholds
             self.write_register(
-                Register::get_treshold_register(
+                Register::get_threshold_register(
                     Channel::try_from(i).expect("Channel Iteration Should not fail"),
                 ),
                 touch,

--- a/src/mpr121.rs
+++ b/src/mpr121.rs
@@ -166,7 +166,7 @@ impl<I2C: I2c> Mpr121<I2C> {
     pub async fn set_thresholds(&mut self, touch: u8, release: u8) -> Result<(), Mpr121Error> {
         for channel in Channel::iter() {
             //Note ignoring false set thresholds
-            self.write_register(Register::get_treshold_register(channel), touch)
+            self.write_register(Register::get_threshold_register(channel), touch)
                 .await?;
             self.write_register(Register::get_release_register(channel), release)
                 .await?;

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -108,7 +108,7 @@ pub enum Register {
 
 impl Register {
     /// Returns the threshold register associated with the channel
-    pub fn get_treshold_register(channel: Channel) -> Register {
+    pub fn get_threshold_register(channel: Channel) -> Register {
         match channel {
             Channel::Channel0 => Register::TouchThreshold0,
             Channel::Channel1 => Register::TouchThreshold1,

--- a/tests-common/Cargo.toml
+++ b/tests-common/Cargo.toml
@@ -1,11 +1,8 @@
 [package]
 name = "tests-common"
-description = "Common tests for the MPR121 Driver that are cross platform"
+description = "Common tests for the MPR121 Driver that are cross platform. Currently using Synchronous Embedded Hal"
 version = "0.1.0"
 edition = "2021"
-
-[features]
-
 
 [dependencies]
 mpr121-hal = {path="../"}

--- a/tests-common/Cargo.toml
+++ b/tests-common/Cargo.toml
@@ -7,7 +7,12 @@ edition = "2021"
 [dependencies]
 mpr121-hal = {path="../"}
 embedded-hal-bus = { version = "0.3.0" }
-maybe-async = {version ="0.2.10"}
 # Embedded HAL traits
-embedded-hal = { version = "1.0" }
+embedded-hal = { version = "1.0", optional = true }
+embedded-hal-async = { version = "1.0", optional = true }
 
+[features]
+
+# Embedded Hal Features
+sync = ["dep:embedded-hal"]
+async = ["dep:embedded-hal-async"]

--- a/tests-common/Cargo.toml
+++ b/tests-common/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "tests-common"
+description = "Common tests for the MPR121 Driver that are cross platform"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+
+
+[dependencies]
+mpr121-hal = {path="../"}
+embedded-hal-bus = { version = "0.3.0" }
+maybe-async = {version ="0.2.10"}
+# Embedded HAL traits
+embedded-hal = { version = "1.0" }
+

--- a/tests-common/src/lib.rs
+++ b/tests-common/src/lib.rs
@@ -1,0 +1,12 @@
+#![no_std]
+use embedded_hal::i2c::I2c;
+use mpr121_hal::mpr121::Mpr121;
+
+#[maybe_async::maybe_async]
+pub async fn generic_test_create_mpr121<I2C>(i2c: I2C)
+where
+    I2C: I2c,
+{
+    let mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, true, true).await;
+    assert!(mpr121_sensor.is_ok());
+}

--- a/tests-common/src/lib.rs
+++ b/tests-common/src/lib.rs
@@ -1,28 +1,32 @@
 #![no_std]
-use embedded_hal::i2c::I2c;
 use mpr121_hal::mpr121::Mpr121;
 
-pub fn generic_test_new<I2C>(i2c: I2C)
-where
-    I2C: I2c,
-{
-    let mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, true, true);
+#[cfg(feature = "sync")]
+mod hal_imports {
+    pub use embedded_hal::delay::DelayNs;
+    pub use embedded_hal::i2c::I2c;
+}
+
+#[cfg(feature = "async")]
+mod hal_imports {
+    pub use embedded_hal_async::delay::DelayNs;
+    pub use embedded_hal_async::i2c::I2c;
+}
+
+use hal_imports::*;
+
+pub fn generic_test_new(i2c: impl I2c, delay: &mut impl DelayNs) {
+    let mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, delay, true, true);
     assert!(mpr121_sensor.is_ok());
 }
 
-pub fn generic_test_new_default<I2C>(i2c: I2C)
-where
-    I2C: I2c,
-{
-    let mpr121_sensor = Mpr121::new_default(i2c);
+pub fn generic_test_new_default(i2c: impl I2c, delay: &mut impl DelayNs) {
+    let mpr121_sensor = Mpr121::new_default(i2c, delay);
     assert!(mpr121_sensor.is_ok());
 }
 
-pub fn generic_test_is_over_current_set<I2C>(i2c: I2C)
-where
-    I2C: I2c,
-{
-    let mut mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, true, true)
+pub fn generic_test_is_over_current_set(i2c: impl I2c, delay: &mut impl DelayNs) {
+    let mut mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, delay, true, true)
         .expect("Sensor Initialisation should not fail");
     let over_current_flag = mpr121_sensor
         .is_over_current_set()
@@ -31,11 +35,8 @@ where
     assert!(!over_current_flag);
 }
 
-pub fn generic_test_get_touched<I2C>(i2c: I2C)
-where
-    I2C: I2c,
-{
-    let mut mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, true, true)
+pub fn generic_test_get_touched(i2c: impl I2c, delay: &mut impl DelayNs) {
+    let mut mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, delay, true, true)
         .expect("Sensor Initialisation should not fail");
     assert!(
         mpr121_sensor

--- a/tests-common/src/lib.rs
+++ b/tests-common/src/lib.rs
@@ -2,11 +2,45 @@
 use embedded_hal::i2c::I2c;
 use mpr121_hal::mpr121::Mpr121;
 
-#[maybe_async::maybe_async]
-pub async fn generic_test_create_mpr121<I2C>(i2c: I2C)
+pub fn generic_test_new<I2C>(i2c: I2C)
 where
     I2C: I2c,
 {
-    let mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, true, true).await;
+    let mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, true, true);
     assert!(mpr121_sensor.is_ok());
+}
+
+pub fn generic_test_new_default<I2C>(i2c: I2C)
+where
+    I2C: I2c,
+{
+    let mpr121_sensor = Mpr121::new_default(i2c);
+    assert!(mpr121_sensor.is_ok());
+}
+
+pub fn generic_test_is_over_current_set<I2C>(i2c: I2C)
+where
+    I2C: I2c,
+{
+    let mut mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, true, true)
+        .expect("Sensor Initialisation should not fail");
+    let over_current_flag = mpr121_sensor
+        .is_over_current_set()
+        .expect("Communication with sensor should not fail");
+
+    assert!(!over_current_flag);
+}
+
+pub fn generic_test_get_touched<I2C>(i2c: I2C)
+where
+    I2C: I2c,
+{
+    let mut mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, true, true)
+        .expect("Sensor Initialisation should not fail");
+    assert!(
+        mpr121_sensor
+            .get_touched()
+            .expect("Communication should not fail")
+            == 0
+    ); // Nothing should be triggered if not connected to anything
 }

--- a/tests/linux.rs
+++ b/tests/linux.rs
@@ -5,7 +5,9 @@ pub mod linux {
 }
 #[cfg(feature = "sync")]
 mod i2c_driver {
+    use embedded_hal::delay::DelayNs;
     use ftdi::Device;
+    use ftdi_embedded_hal::Delay;
     use ftdi_embedded_hal::{self as hal, I2c};
     use std::error::Error;
 
@@ -36,11 +38,7 @@ mod i2c_driver {
         };
         Ok(i2c)
     }
-}
-
-#[cfg(feature = "async")]
-mod i2c_driver {
-    pub fn setup_i2c() {
-        todo!("Not Implemented yet");
+    pub fn setup_delay() -> impl DelayNs {
+        return Delay::new();
     }
 }

--- a/tests/linux.rs
+++ b/tests/linux.rs
@@ -1,3 +1,4 @@
+//! Linux / MacOS Specific Tests, responsible for creating the I2C Device thriugh the FT232H Breakout Board. These tests run in sync mode
 #[cfg(test)]
 pub mod linux {
     pub mod tests;

--- a/tests/linux.rs
+++ b/tests/linux.rs
@@ -1,0 +1,45 @@
+#[cfg(test)]
+pub mod linux {
+    pub mod tests;
+}
+#[cfg(feature = "sync")]
+mod i2c_driver {
+    use ftdi::Device;
+    use ftdi_embedded_hal::{self as hal, I2c};
+    use std::error::Error;
+
+    pub fn setup_i2c() -> Result<I2c<Device>, Box<dyn Error>> {
+        const BAUDRATE: u32 = 400_000;
+        // Change these for your device
+        const DEVICE_VID: u16 = 0x0403;
+        const DEVICE_PID: u16 = 0x6014;
+
+        let device = ftdi::find_by_vid_pid(DEVICE_VID, DEVICE_PID)
+            .interface(ftdi::Interface::A)
+            .open()?;
+        // Next initialise the HAL with the device and the Baudrate
+        let hal = match hal::FtHal::init_freq(device, BAUDRATE) {
+            Ok(hal) => hal,
+            Err(err) => {
+                eprintln!("Failed to initialise HAL: {}", err);
+                return Err(Box::new(err));
+            }
+        };
+        // Finally initialise the I2C with the HAL
+        let i2c = match hal.i2c() {
+            Ok(i2c) => i2c,
+            Err(err) => {
+                eprintln!("Failed to initialise I2C: {}", err);
+                return Err(Box::new(err));
+            }
+        };
+        Ok(i2c)
+    }
+}
+
+#[cfg(feature = "async")]
+mod i2c_driver {
+    pub fn setup_i2c() {
+        todo!("Not Implemented yet");
+    }
+}

--- a/tests/linux.rs
+++ b/tests/linux.rs
@@ -39,6 +39,6 @@ mod i2c_driver {
         Ok(i2c)
     }
     pub fn setup_delay() -> impl DelayNs {
-        return Delay::new();
+        Delay::new()
     }
 }

--- a/tests/linux/tests.rs
+++ b/tests/linux/tests.rs
@@ -1,0 +1,7 @@
+use crate::i2c_driver;
+use tests_common::*;
+
+pub async fn test_create_mpr121() {
+    let i2c_bus = i2c_driver::setup_i2c().expect("I2C Bus failed to acquire");
+    generic_test_create_mpr121(i2c_bus);
+}

--- a/tests/linux/tests.rs
+++ b/tests/linux/tests.rs
@@ -1,22 +1,27 @@
 use crate::i2c_driver;
 use tests_common::*;
+
 #[test]
 pub fn test_new() {
     let i2c_bus = i2c_driver::setup_i2c().expect("I2C Bus failed to acquire");
-    generic_test_new(i2c_bus);
+    let mut delay = i2c_driver::setup_delay();
+    generic_test_new(i2c_bus, &mut delay);
 }
 #[test]
 pub fn test_new_default() {
     let i2c_bus = i2c_driver::setup_i2c().expect("I2C Bus failed to acquire");
-    generic_test_new_default(i2c_bus);
+    let mut delay = i2c_driver::setup_delay();
+    generic_test_new_default(i2c_bus, &mut delay);
 }
 #[test]
 pub fn test_is_over_current_set() {
     let i2c_bus = i2c_driver::setup_i2c().expect("I2C Bus failed to acquire");
-    generic_test_is_over_current_set(i2c_bus);
+    let mut delay = i2c_driver::setup_delay();
+    generic_test_is_over_current_set(i2c_bus, &mut delay);
 }
 #[test]
 pub fn test_get_touched() {
     let i2c_bus = i2c_driver::setup_i2c().expect("I2C Bus failed to acquire");
-    generic_test_get_touched(i2c_bus);
+    let mut delay = i2c_driver::setup_delay();
+    generic_test_get_touched(i2c_bus, &mut delay);
 }

--- a/tests/linux/tests.rs
+++ b/tests/linux/tests.rs
@@ -1,7 +1,22 @@
 use crate::i2c_driver;
 use tests_common::*;
-
-pub async fn test_create_mpr121() {
+#[test]
+pub fn test_new() {
     let i2c_bus = i2c_driver::setup_i2c().expect("I2C Bus failed to acquire");
-    generic_test_create_mpr121(i2c_bus);
+    generic_test_new(i2c_bus);
+}
+#[test]
+pub fn test_new_default() {
+    let i2c_bus = i2c_driver::setup_i2c().expect("I2C Bus failed to acquire");
+    generic_test_new_default(i2c_bus);
+}
+#[test]
+pub fn test_is_over_current_set() {
+    let i2c_bus = i2c_driver::setup_i2c().expect("I2C Bus failed to acquire");
+    generic_test_is_over_current_set(i2c_bus);
+}
+#[test]
+pub fn test_get_touched() {
+    let i2c_bus = i2c_driver::setup_i2c().expect("I2C Bus failed to acquire");
+    generic_test_get_touched(i2c_bus);
 }


### PR DESCRIPTION
# Description

Im hoping this is a good start to a Test harness, I wont have time to fully implement but it gives us a starting point. Essentially we have common tests stored in a tests-common folder in which our tests folder can use directly as a dev dependencies. At the moment these tests are purely synchronous tests. We can then pull these generic tests into different MCU projects within the test folder using the `embedded-test` framework this ensures our driver is truly platform agnostic  and continues to work.


The PR for this is quite large as its branched off the PR #6.
## Type of change

Please score/delete out the options that are not relevant.

- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

This PR has added the repos first set of tests, all be it simple but effective.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I Have locally ran [MegaLinter](https://megalinter.io/latest/supported-linters/) see [README](../README.md) for more details. You can use the following Bash/zsh command: `npx mega-linter-runner --fix`
