### PR TITLE
Remove check reset flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "mpr121-hal"
-version = "0.6.0"
+version = "0.5.0"
 dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",

--- a/examples/esp32s3/src/main.rs
+++ b/examples/esp32s3/src/main.rs
@@ -50,15 +50,9 @@ async fn main(spawner: Spawner) {
         ))
     };
     let i2c = I2cDevice::new(i2c_bus);
-    let mut mpr121 = Mpr121::new(
-        i2c,
-        Mpr121Address::Default,
-        &mut embassy_time::Delay,
-        true,
-        true,
-    )
-    .await
-    .expect("Failed to initialize MPR121");
+    let mut mpr121 = Mpr121::new(i2c, Mpr121Address::Default, &mut embassy_time::Delay, true)
+        .await
+        .expect("Failed to initialize MPR121");
 
     loop {
         // Read the touch status

--- a/examples/os_sync_basic.rs
+++ b/examples/os_sync_basic.rs
@@ -19,7 +19,6 @@ fn main() {
         mpr121_hal::Mpr121Address::Default,
         &mut Delay::new(),
         true,
-        true,
     )
     .unwrap();
     loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,10 +38,9 @@ pub enum Mpr121Error {
     WriteError(Register),
     ///If sending the reset signal failed, contains the register that failed.
     ResetFailed { was_read: bool, reg: Register },
-    ///If the reset did not happen as expected. if ovcp is set, the reset failed because over-current protection
-    /// is active.
-    InitFailed { over_current_protection: bool },
-    /// Wrong Device Connected
+    /// During Startup if there is an overcurrent detection, the driver will fail to initialise indicating a hardware fault
+    OverCurrent,
+    /// Wrong Device Connected, this can also happen if the device state is invalid possible due to a short circuit/overcurrent event
     WrongDevice {
         mismatched_register: Register,
         expected: u8,

--- a/src/mpr121.rs
+++ b/src/mpr121.rs
@@ -191,7 +191,7 @@ impl<I2C: I2c> Mpr121<I2C> {
     ///
     /// In the event of an error [Mpr121Error] is returned
     #[maybe_async::maybe_async]
-    async fn is_over_current_set(&mut self) -> Result<bool, Mpr121Error> {
+    pub async fn is_over_current_set(&mut self) -> Result<bool, Mpr121Error> {
         const OVER_CURRENT_PROTECTION_FLAG_MASK: u8 = 0b1 << 7;
         let read = self.read_reg8(Register::TouchStatus8_11).await?;
         //If bit D7 is set, we have OVCF

--- a/src/mpr121.rs
+++ b/src/mpr121.rs
@@ -208,7 +208,7 @@ impl<I2C: I2c> Mpr121<I2C> {
         for i in 0..Channel::NUM_CHANNELS {
             //Note ignoring false set thresholds
             self.write_register(
-                Register::get_treshold_register(
+                Register::get_threshold_register(
                     Channel::try_from(i).expect("Channel Iteration Should not fail"),
                 ),
                 touch,

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -108,7 +108,7 @@ pub enum Register {
 
 impl Register {
     /// Returns the threshold register associated with the channel
-    pub fn get_treshold_register(channel: Channel) -> Register {
+    pub fn get_threshold_register(channel: Channel) -> Register {
         match channel {
             Channel::Zero => Register::TouchThreshold0,
             Channel::One => Register::TouchThreshold1,


### PR DESCRIPTION
# Description

After the refactor conducted in PR #6, I found that the check_reset_flags functionality may no longer be required. Ive otped to do a small refactor in this PR to isolate the discussion on it. Ive also descoped the 

- [x] Merge PR https://github.com/SiebenCorgie/mpr121-hal/pull/6 to see smaller PR changes

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected) 

## How Has This Been Tested?

Ive tested by running both examples and they still work independently of each other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I Have locally ran [MegaLinter](https://megalinter.io/latest/supported-linters/) see [README](../README.md) for more details. You can use the following Bash/zsh command: `npx mega-linter-runner --fix`
