### PR TITLE
updated test harness library api

### DIFF
--- a/tests-common/src/lib.rs
+++ b/tests-common/src/lib.rs
@@ -16,7 +16,7 @@ mod hal_imports {
 use hal_imports::*;
 
 pub fn generic_test_new(i2c: impl I2c, delay: &mut impl DelayNs) {
-    let mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, delay, true, true);
+    let mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, delay, true);
     assert!(mpr121_sensor.is_ok());
 }
 
@@ -26,7 +26,7 @@ pub fn generic_test_new_default(i2c: impl I2c, delay: &mut impl DelayNs) {
 }
 
 pub fn generic_test_is_over_current_set(i2c: impl I2c, delay: &mut impl DelayNs) {
-    let mut mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, delay, true, true)
+    let mut mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, delay, true)
         .expect("Sensor Initialisation should not fail");
     let over_current_flag = mpr121_sensor
         .is_over_current_set()
@@ -36,7 +36,7 @@ pub fn generic_test_is_over_current_set(i2c: impl I2c, delay: &mut impl DelayNs)
 }
 
 pub fn generic_test_get_touched(i2c: impl I2c, delay: &mut impl DelayNs) {
-    let mut mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, delay, true, true)
+    let mut mpr121_sensor = Mpr121::new(i2c, mpr121_hal::Mpr121Address::Default, delay, true)
         .expect("Sensor Initialisation should not fail");
     assert!(
         mpr121_sensor


### PR DESCRIPTION
# Description

The Test Harness was outdated with the new API change. Ive added the update here and it should allow it to pass all the CI build stages. If we merge this into the dependabot ftdi branch, it should then pass all the CI for the dependabot update

## Type of change

Please score/delete out the options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Ran locally and in CI

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I Have locally ran [MegaLinter](https://megalinter.io/latest/supported-linters/) see [README](../README.md) for more details. You can use the following Bash/zsh command: `npx mega-linter-runner --fix`
